### PR TITLE
fixed top right button where discord invite link is expired

### DIFF
--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -153,7 +153,7 @@
                         </a>
                         {{/if}}
                         
-                        <a href="https://discord.gg/together-java" title="Ask a question" aria-label="Ask a question">
+                        <a href="https://discord.gg/GzvQjhv" title="Ask a question" aria-label="Ask a question">
                             <i id="ask-a-question-button" class="fa fa-question"></i>
                         </a>
                     </div>


### PR DESCRIPTION
fixed the discord link on line 156 of theme/index.hbs, before the fix the button(on the top right corner of the page) would take users to a expired discord invite link to the server, now that i updated the link to a newer one it should work.