### PR TITLE
Fix infinite loop in 12.4 Continue

### DIFF
--- a/src/loops/continue.md
+++ b/src/loops/continue.md
@@ -10,6 +10,7 @@ The only other situation this will not happen is if a `continue` statement is re
 int x = 5;
 while (x > 0) {
     if (x == 4) {
+        x--; // Make sure the loop continues to 3
         continue;
     }
     IO.println(x + " is a good number");


### PR DESCRIPTION
The code example in 12.4 Continue contains an infinite loop because `x` does not decrement from 4 to 3. This PR fixes it.