### PR TITLE
Objects Challenges: Remove double call to Math.random()

### DIFF
--- a/src/objects/challenges.md
+++ b/src/objects/challenges.md
@@ -34,7 +34,7 @@ class Broom {
 class Witch {
     Object pullFromHat() {
         double r = Math.random();
-        if (Math.random() < 0.25) {
+        if (r < 0.25) {
             return new Spell("Ensmallen");
         }
         else if (r < 0.5) {


### PR DESCRIPTION
In Objects challenges, `Math.random()` is called a second time where the code clearly intended to use the variable `r` instead.