### PR TITLE
Exports: Fix typo

### DIFF
--- a/src/modules/exports.md
+++ b/src/modules/exports.md
@@ -33,7 +33,7 @@ package sky;
 // But classes within other packages of
 // the "reality" module can see it just fine.
 public class Cloud {
-    private final YelloCarpet fabricOfExistence
+    private final YellowCarpet fabricOfExistence
         = new YellowCarpet();
 
     // ...


### PR DESCRIPTION
In Modules -> Exports, `YellowCarpet` is misspelled as `YelloCarpet`.