### PR TITLE
Method References: Fix doDrum call in lambda

### DIFF
--- a/src/lambdas/method_references.md
+++ b/src/lambdas/method_references.md
@@ -17,7 +17,7 @@ class Main {
     }
 
     void main() {
-        Drummer drummer = () -> drum();
+        Drummer drummer = () -> doDrum();
         drummer.drum();
     }
 }


### PR DESCRIPTION
In Lambdas -> Method References, the lambda `() -> drum()` should read `() -> doDrum()`.