### PR TITLE
Invoke a Method: Clarify how the first argument works for static methods

### DIFF
--- a/src/reflection/invoke_a_method.md
+++ b/src/reflection/invoke_a_method.md
@@ -37,7 +37,7 @@ class Tea {
 ```
 
 For static methods you do not need an instance of the class to invoke them.
-Instead you need to pass the class itself as the first argument to `.invoke`.
+Instead, the first argument is ignored. You can pass `null`.
 
 ```java
 import java.lang.reflect.InvocationTargetException;
@@ -55,8 +55,8 @@ class Main {
             throw new RuntimeException(e);
         }
 
-        biteMethod.invoke(Apple.class, 5);
-        biteMethod.invoke(Apple.class, 1);
+        biteMethod.invoke(null, 5);
+        biteMethod.invoke(null, 1);
     }
 }
 


### PR DESCRIPTION
When calling a static method reflectively, the first argument does not actually need to be the class object. The first argument is ignored, and official documentation points out you can pass `null`.