### PR TITLE
Fixed type from int to double in scope code blocks

### DIFF
--- a/src/static_methods/scope.md
+++ b/src/static_methods/scope.md
@@ -5,7 +5,7 @@ and you can reference other static fields and methods.
 
 ```java,no_run
 class ScopeExample {
-    static final int CAN_ACCESS = 3.14;
+    static final double CAN_ACCESS = 3.14;
 
     static void canCall() {
     }
@@ -21,7 +21,7 @@ But you cannot access any non-static methods or fields. They are not in scope.
 
 ```java,no_run,does_not_compile
 class ScopeExample2 {
-    final int CANNOT_ACCESS = 3.14;
+    final double CANNOT_ACCESS = 3.14;
 
     void cannotCall() {
     }


### PR DESCRIPTION
In Chapter 43.2 - Scope. The code blocks indicate a variable named `CAN_ACCESS` and `CANNOT_ACCESS` with a type of int but the value is of type double.