### PR TITLE
Class RoadRunner needed to implement Runner

### DIFF
--- a/src/class_extension/relation_to_interfaces.md
+++ b/src/class_extension/relation_to_interfaces.md
@@ -15,7 +15,7 @@ interface Runner {
     }
 }
 
-class RoadRunner {
+class RoadRunner implements Runner {
     @Override
     public void run() {
         IO.println("meep meep");


### PR DESCRIPTION
Lesson 67.7 - Relation to Interfaces, missing `implements Runner` to the very first code block.