### PR TITLE
fix: correct singer reference from woodkid to twrp in arguments example

### DIFF
--- a/src/lambdas/arguments.md
+++ b/src/lambdas/arguments.md
@@ -47,7 +47,7 @@ class Main {
             );
         };
 
-        woodkid.sing("Pets", 7);
+        twrp.sing("Pets", 7);
     }
 }
 ```


### PR DESCRIPTION
second example uses twrp instead of woodkid